### PR TITLE
feat: add `--no-spa` flag

### DIFF
--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -222,6 +222,10 @@ pub struct ConfigOptsServe {
     #[arg(long = "no-error-reporting")]
     #[serde(default)]
     pub no_error_reporting: bool,
+    /// Disable fallback to index.html for missing files [default: false]
+    #[arg(long = "no-spa")]
+    #[serde(default)]
+    pub no_spa: bool,
     /// Protocol used for the auto-reload WebSockets connection [enum: ws, wss]
     #[arg(long = "ws-protocol")]
     pub ws_protocol: Option<WsProtocol>,
@@ -454,6 +458,7 @@ impl ConfigOpts {
             no_autoreload: cli.no_autoreload,
             headers: cli.headers,
             no_error_reporting: cli.no_error_reporting,
+            no_spa: cli.no_spa,
             ws_protocol: cli.ws_protocol,
             tls_key_path: cli.tls_key_path,
             tls_cert_path: cli.tls_cert_path,
@@ -655,6 +660,10 @@ impl ConfigOpts {
                 // NOTE: this can not be disabled in the cascade.
                 if l.no_autoreload {
                     g.no_autoreload = true;
+                }
+                // NOTE: this can not be disabled in the cascade.
+                if l.no_spa {
+                    g.no_spa = true;
                 }
                 // NOTE: this can not be disabled in the cascade.
                 if l.open {

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -285,6 +285,8 @@ pub struct RtcServe {
     pub proxies: Option<Vec<ConfigOptsProxy>>,
     /// Whether to disable auto-reload of the web page when a build completes.
     pub no_autoreload: bool,
+    /// Whether to disable fallback to index.html for missing files.
+    pub no_spa: bool,
     /// Additional headers to include in responses.
     pub headers: HashMap<String, String>,
     /// Protocol used for autoreload WebSockets connection.
@@ -326,6 +328,7 @@ impl RtcServe {
             proxy_ws: opts.proxy_ws,
             proxies,
             no_autoreload: opts.no_autoreload,
+            no_spa: opts.no_spa,
             headers: opts.headers,
             ws_protocol: opts.ws_protocol,
             tls,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -256,9 +256,11 @@ fn router(state: Arc<State>, cfg: Arc<RtcServe>) -> Result<Router> {
             .unwrap_or(&state.public_url)
     };
 
-    let mut serve_dir = get_service(
-        ServeDir::new(&state.dist_dir).fallback(ServeFile::new(state.dist_dir.join(INDEX_HTML))),
-    );
+    let mut serve_dir = if cfg.no_spa {
+        get_service(ServeDir::new(&state.dist_dir))
+    } else {
+        get_service(ServeDir::new(&state.dist_dir).fallback(ServeFile::new(state.dist_dir.join(INDEX_HTML))))
+    };
     for (key, value) in &state.headers {
         let name = HeaderName::from_bytes(key.as_bytes())
             .with_context(|| format!("invalid header {:?}", key))?;


### PR DESCRIPTION
Add `--no-spa` flag for `serve` subcommand.

When invoked with this flag (e.g. `trunk-ng serve --no-spa`), `trunk-ng` will respond with `HTTP 404 Not Found` to requests for any missing static files instead of falling back to `HTTP 200 OK` with `index.html` (default behavior, without the flag).

I implemented this in the most obviously way that addressed my (very limited) use case. It's quite possible I've failed to consider other use cases. If so, I'll gladly make any adjustments to get this merged.

Closes #3 