### PR TITLE
Update tool versions; Improve logging #2

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -53,13 +53,13 @@ cargo = false
 
 [tools]
 # Default dart-sass version to download.
-sass = "1.54.9"
+sass = "1.69.5"
 # Default wasm-bindgen version to download.
-wasm_bindgen = "0.2.83"
+wasm_bindgen = "0.2.88"
 # Default wasm-opt version to download.
-wasm_opt = "version_110"
+wasm_opt = "version_116"
 # Default tailwindcss-cli version to download.
-tailwindcss = "3.3.2"
+tailwindcss = "3.3.5"
 
 ## proxy
 # Proxies are optional, and default to `None`.

--- a/src/build.rs
+++ b/src/build.rs
@@ -64,7 +64,12 @@ impl BuildSystem {
         // Ensure the output dist directories are in place.
         fs::create_dir_all(self.cfg.final_dist.as_path())
             .await
-            .with_context(|| "error creating build environment directory: dist")?;
+            .with_context(|| {
+                format!(
+                    "error creating build environment directory: {}",
+                    self.cfg.final_dist.display()
+                )
+            })?;
 
         self.prepare_staging_dist()
             .await
@@ -94,12 +99,19 @@ impl BuildSystem {
         let staging_dist = self.cfg.staging_dist.as_path();
 
         // Clean staging area, if applicable
-        remove_dir_all(staging_dist.into())
-            .await
-            .context("error cleaning staging dist dir")?;
-        fs::create_dir_all(staging_dist)
-            .await
-            .with_context(|| "error creating build environment directory: staging dist dir")?;
+        remove_dir_all(staging_dist.into()).await.with_context(|| {
+            format!(
+                "error cleaning staging dist dir: {}",
+                staging_dist.display()
+            )
+        })?;
+
+        fs::create_dir_all(staging_dist).await.with_context(|| {
+            format!(
+                "error creating build environment directory: {}",
+                staging_dist.display()
+            )
+        })?;
 
         Ok(())
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -97,9 +97,17 @@ pub async fn remove_dir_all(from_dir: PathBuf) -> Result<()> {
 
 /// Checks if path exists.
 pub async fn path_exists(path: impl AsRef<Path>) -> Result<bool> {
+    path_exists_and(path, |_| true).await
+}
+
+/// Checks if path exists and metadata matches the given predicate.
+pub async fn path_exists_and(
+    path: impl AsRef<Path>,
+    and: impl FnOnce(Metadata) -> bool,
+) -> Result<bool> {
     tokio::fs::metadata(path.as_ref())
         .await
-        .map(|_| true)
+        .map(and)
         .or_else(|error| {
             if error.kind() == ErrorKind::NotFound {
                 Ok(false)
@@ -162,12 +170,20 @@ pub async fn run_command(
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .spawn()
-        .with_context(|| format!("error spawning {name} call ({path})", path = path.display()))?
+        .with_context(|| {
+            format!(
+                "error running {name} using executable '{}' with args: '{args:?}'",
+                path.display(),
+            )
+        })?
         .wait()
         .await
         .with_context(|| format!("error during {name} call"))?;
     if !status.success() {
-        bail!("{name} call returned a bad status");
+        bail!(
+            "{name} call to executable '{}' with args: '{args:?}' returned a bad status: {status}",
+            path.display()
+        );
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use anyhow::{Context, Result};
 use clap::{ArgAction, Parser, Subcommand};
 use common::STARTING;
 use std::path::PathBuf;
-use tracing::log;
 use tracing_subscriber::prelude::*;
 
 #[tokio::main]
@@ -43,7 +42,7 @@ async fn main() -> Result<()> {
         .try_init()
         .context("error initializing logging")?;
 
-    log::info!(
+    tracing::info!(
         "{} Starting {} {}",
         STARTING,
         env!("CARGO_PKG_NAME"),

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -495,16 +495,13 @@ impl RustApp {
 
         tracing::debug!(
             "copying {js_loader_path} to {}",
-            js_loader_path_dist.to_string_lossy()
+            js_loader_path_dist.display()
         );
         self.copy_or_minify_js(js_loader_path, &js_loader_path_dist)
             .await
             .context("error minifying or copying JS loader file to stage dir")?;
 
-        tracing::debug!(
-            "copying {wasm_path} to {}",
-            wasm_path_dist.to_string_lossy()
-        );
+        tracing::debug!("copying {wasm_path} to {}", wasm_path_dist.display());
 
         fs::copy(wasm_path, wasm_path_dist)
             .await
@@ -514,14 +511,14 @@ impl RustApp {
             let ts_path = bindgen_out.join(&hashed_ts_name);
             let ts_path_dist = self.cfg.staging_dist.join(&hashed_ts_name);
 
-            tracing::debug!("copying {ts_path} to {}", ts_path_dist.to_string_lossy());
+            tracing::debug!("copying {ts_path} to {}", ts_path_dist.display());
             fs::copy(ts_path, ts_path_dist)
                 .await
                 .context("error copying TS files to stage dir")?;
         }
 
         if let Some(ref m) = loader_shim_path {
-            tracing::debug!("creating {}", m.to_string_lossy());
+            tracing::debug!("creating {}", m.display());
             let mut loader_f = fs::File::create(m)
                 .await
                 .context("error creating loader shim script")?;
@@ -554,7 +551,7 @@ impl RustApp {
             let snippets_dir_dest = self.cfg.staging_dist.join(SNIPPETS_DIR);
             tracing::debug!(
                 "recursively copying from '{snippets_dir_src}' to '{}'",
-                snippets_dir_dest.to_string_lossy()
+                snippets_dir_dest.display()
             );
             copy_dir_recursive(snippets_dir_src, snippets_dir_dest)
                 .await

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -14,7 +14,7 @@ use tokio::process::Command;
 use tokio::sync::{Mutex, OnceCell};
 
 use self::archive::Archive;
-use crate::common::is_executable;
+use crate::common::{is_executable, path_exists, path_exists_and};
 
 /// The application to locate and eventually download when calling [`get`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -84,10 +84,10 @@ impl Application {
     /// Default version to use if not set by the user.
     fn default_version(&self) -> &str {
         match self {
-            Self::Sass => "1.63.6",
-            Self::TailwindCss => "3.3.2",
-            Self::WasmBindgen => "0.2.87",
-            Self::WasmOpt => "version_113",
+            Self::Sass => "1.69.5",
+            Self::TailwindCss => "3.3.5",
+            Self::WasmBindgen => "0.2.88",
+            Self::WasmOpt => "version_116",
         }
     }
 
@@ -113,10 +113,10 @@ impl Application {
 
         Ok(match self {
             Self::Sass => match (target_os, target_arch) {
-              ("windows", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-windows-x64.zip"),
-              ("macos" | "linux", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-x64.tar.gz"),
-              ("macos" | "linux", "aarch64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-arm64.tar.gz"),
-              _ => bail!("Unable to download Sass for {target_os} {target_arch}")
+                ("windows", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-windows-x64.zip"),
+                ("macos" | "linux", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-x64.tar.gz"),
+                ("macos" | "linux", "aarch64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-arm64.tar.gz"),
+                _ => bail!("Unable to download Sass for {target_os} {target_arch}")
             },
 
             Self::TailwindCss => match (target_os, target_arch) {
@@ -127,17 +127,17 @@ impl Application {
             },
 
             Self::WasmBindgen => match (target_os, target_arch) {
-              ("windows", "x86_64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-x86_64-pc-windows-msvc.tar.gz"),
-              ("macos", "x86_64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-x86_64-apple-darwin.tar.gz"),
-              ("macos", "aarch64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-aarch64-apple-darwin.tar.gz"),
-              ("linux", "x86_64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-x86_64-unknown-linux-musl.tar.gz"),
-              ("linux", "aarch64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-aarch64-unknown-linux-gnu.tar.gz"),
-              _ => bail!("Unable to download wasm-bindgen for {target_os} {target_arch}")
+                ("windows", "x86_64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-x86_64-pc-windows-msvc.tar.gz"),
+                ("macos", "x86_64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-x86_64-apple-darwin.tar.gz"),
+                ("macos", "aarch64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-aarch64-apple-darwin.tar.gz"),
+                ("linux", "x86_64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-x86_64-unknown-linux-musl.tar.gz"),
+                ("linux", "aarch64") => format!("https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-aarch64-unknown-linux-gnu.tar.gz"),
+                _ => bail!("Unable to download wasm-bindgen for {target_os} {target_arch}")
             },
 
             Self::WasmOpt => match (target_os, target_arch) {
-              ("macos", "aarch64") => format!("https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-arm64-macos.tar.gz"),
-              _ => format!("https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-{target_arch}-{target_os}.tar.gz")
+                ("macos", "aarch64") => format!("https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-arm64-macos.tar.gz"),
+                _ => format!("https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-{target_arch}-{target_os}.tar.gz")
             }
         })
     }
@@ -327,11 +327,12 @@ async fn download(app: Application, version: &str) -> Result<PathBuf> {
 /// Install an application from a downloaded archive locating and copying it to the given target
 /// location.
 #[tracing::instrument(level = "trace")]
-async fn install(app: Application, archive_file: File, target: PathBuf) -> Result<()> {
+async fn install(app: Application, archive_file: File, target_directory: PathBuf) -> Result<()> {
     tracing::info!("installing {}", app.name());
 
     let archive_file = archive_file.into_std().await;
 
+    let target_directory_clone = target_directory.clone();
     tokio::task::spawn_blocking(move || {
         let mut archive = if app == Application::Sass && cfg!(target_os = "windows") {
             Archive::new_zip(archive_file)?
@@ -340,12 +341,12 @@ async fn install(app: Application, archive_file: File, target: PathBuf) -> Resul
         } else {
             Archive::new_tar_gz(archive_file)
         };
-        archive.extract_file(app.path(), &target)?;
+        archive.extract_file(app.path(), &target_directory)?;
 
         for path in app.extra_paths() {
             // After extracting one file the archive must be reset.
             archive = archive.reset()?;
-            if archive.extract_file(path, &target).is_err() {
+            if archive.extract_file(path, &target_directory).is_err() {
                 tracing::warn!(
                     "attempted to extract '{}' from {:?} archive, but it is not present, this \
                      could be due to version updates",
@@ -355,9 +356,32 @@ async fn install(app: Application, archive_file: File, target: PathBuf) -> Resul
             }
         }
 
-        Ok(())
+        Result::<()>::Ok(())
     })
-    .await?
+    .await
+    .context("Unable to join on spawn_blocking")?
+    .context("Could not extract files")?;
+
+    let main_executable = target_directory_clone.join(app.path());
+    let test = path_exists(&main_executable).await;
+    ensure!(
+        test.ok() == Some(true),
+        "Extracted application binary {main_executable:?} could not be found."
+    );
+
+    let test = path_exists_and(&main_executable, |m| m.is_file()).await;
+    ensure!(
+        test.ok() == Some(true),
+        "Extracted application binary {main_executable:?} is not a file"
+    );
+
+    let test = is_executable(&main_executable).await;
+    ensure!(
+        test.ok() == Some(true),
+        "Extracted application binary {main_executable:?} is not executable."
+    );
+
+    Ok(())
 }
 
 /// Locate the cache dir for trunk and make sure it exists.
@@ -403,47 +427,50 @@ mod archive {
             Self::None(file)
         }
 
-        pub fn extract_file(&mut self, file: &str, target: &Path) -> Result<()> {
+        pub fn extract_file(&mut self, file: &str, target_directory: &Path) -> Result<()> {
             match self {
                 Self::TarGz(archive) => {
                     let mut tar_file =
                         find_tar_entry(archive, file)?.context("file not found in archive")?;
-                    let mut out_file = extract_file(&mut tar_file, file, target)?;
+                    let mut out_file = extract_file(&mut tar_file, file, target_directory)?;
 
                     if let Ok(mode) = tar_file.header().mode() {
-                        set_file_permissions(&mut out_file, mode)?;
+                        set_file_permissions(&mut out_file, mode, Some(file))?;
                     }
                 }
                 Self::Zip(archive) => {
                     let zip_index =
                         find_zip_entry(archive, file)?.context("file not found in archive")?;
                     let mut zip_file = archive.by_index(zip_index)?;
-                    let mut out_file = extract_file(&mut zip_file, file, target)?;
+                    let mut out_file = extract_file(&mut zip_file, file, target_directory)?;
 
                     if let Some(mode) = zip_file.unix_mode() {
-                        set_file_permissions(&mut out_file, mode)?;
+                        set_file_permissions(&mut out_file, mode, Some(file))?;
                     }
                 }
                 Self::None(in_file) => {
-                    let create_dir_result = std::fs::create_dir(target);
+                    let create_dir_result = std::fs::create_dir(target_directory);
                     if let Err(e) = &create_dir_result {
                         if e.kind() != std::io::ErrorKind::AlreadyExists {
                             create_dir_result.context("failed to open file for")?;
                         }
                     }
 
-                    let mut out_file_path = target.to_path_buf();
+                    let mut out_file_path = target_directory.to_path_buf();
                     out_file_path.push(file);
                     let mut out_file =
-                        File::create(out_file_path).context("failed to open binary to copy")?;
+                        File::create(&out_file_path).context("failed to open binary to copy")?;
                     {
                         let mut reader = BufReader::new(in_file);
                         let mut writer = BufWriter::new(&out_file);
 
                         std::io::copy(&mut reader, &mut writer).context("failed to copy binary")?;
                     }
-                    set_file_permissions(&mut out_file, 0o755)?; // rwx for user, rx for group and
-                                                                 // other.
+                    set_file_permissions(
+                        &mut out_file,
+                        0o755,
+                        Some(out_file_path.to_string_lossy()),
+                    )?;
                 }
             }
 
@@ -514,14 +541,15 @@ mod archive {
         Ok(None)
     }
 
-    fn extract_file(mut read: impl Read, file: &str, target: &Path) -> Result<File> {
-        let out = target.join(file);
+    fn extract_file(mut read: impl Read, file: &str, target_directory: &Path) -> Result<File> {
+        let out = target_directory.join(file);
 
         if let Some(parent) = out.parent() {
             fs::create_dir_all(parent).context("failed creating output directory")?;
         }
 
-        let mut out = File::create(target.join(file)).context("failed creating output file")?;
+        let mut out =
+            File::create(target_directory.join(file)).context("failed creating output file")?;
         io::copy(&mut read, &mut out)
             .context("failed copying over final output file from archive")?;
 
@@ -529,11 +557,22 @@ mod archive {
     }
 
     /// Set the executable flag for a file. Only has an effect on UNIX platforms.
-    fn set_file_permissions(file: &mut File, mode: u32) -> Result<()> {
+    fn set_file_permissions(
+        file: &mut File,
+        mode: u32,
+        file_path_hint: Option<impl AsRef<str>>,
+    ) -> Result<()> {
         #[cfg(unix)]
         {
             use std::fs::Permissions;
             use std::os::unix::fs::PermissionsExt;
+
+            match file_path_hint {
+                Some(path) => {
+                    tracing::debug!("Setting permission of '{}' to {mode:#o}", path.as_ref())
+                }
+                None => tracing::debug!("Setting permission of 'unknown file' to {mode:#o}"),
+            };
 
             file.set_permissions(Permissions::from_mode(mode))
                 .context("failed setting file permissions")?;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -16,7 +16,6 @@ use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, watch, Mutex};
 use tokio::time::Instant;
 use tokio_stream::wrappers::BroadcastStream;
-use tracing::log;
 
 pub enum FsDebouncer {
     Default(Debouncer<RecommendedWatcher, FileIdMap>),
@@ -111,7 +110,7 @@ impl WatchSystem {
 
         // Cooldown
         let watcher_cooldown = cfg.enable_cooldown.then_some(WATCHER_COOLDOWN);
-        log::debug!(
+        tracing::debug!(
             "Build cooldown: {:?}",
             watcher_cooldown.map(humantime::Duration::from)
         );
@@ -161,7 +160,7 @@ impl WatchSystem {
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn build_complete(&mut self, build_result: Result<(), anyhow::Error>) {
-        log::debug!("Build reported completion");
+        tracing::debug!("Build reported completion");
 
         // record last finish timestamp
         self.last_build_finished = Instant::now();
@@ -343,7 +342,7 @@ fn build_watcher(
     // Build the filesystem watcher & debouncer.
 
     if let Some(duration) = poll {
-        log::info!(
+        tracing::info!(
             "Running in polling mode: {}",
             humantime::Duration::from(duration)
         );


### PR DESCRIPTION
Addresses https://github.com/ctron/trunk/issues/5

- Replaces `tracing::log::debug/info` with `tracing::debug/info`
- Some error message now including more information
- Tool installation now checks that the main executable exists, is a file and is actually executable
- We now cehck that the path to the style source exists and is a file before running the SASS tool
- Also updates tool versions
  -   Sass: "1.63.6" => "1.69.5"
  -   TailwindCss: "3.3.2" => "3.3.5"
  -   WasmBindgen: "0.2.87" => "0.2.88"
  -   WasmOpt: "version_113" => "version_116"